### PR TITLE
Feat/aws credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 coverage
 untracked
 bin
+.idea

--- a/cmd/index.ts
+++ b/cmd/index.ts
@@ -21,6 +21,21 @@ yargs
       process.exit(1)
     }
   })
+  .option("access-key-id", {
+    alias: "a",
+    describe: "AWS access key ID",
+    type: "string"
+  })
+  .option("secret-access-key", {
+    alias: "k",
+    describe: "AWS secret access key",
+    type: "string"
+  })
+  .option("session-token", {
+    alias: "t",
+    describe: "AWS session token",
+    type: "string"
+  })
   .option("size", {
     alias: "s",
     describe: "Size of upload parts in MB",

--- a/src/app/config/Config.ts
+++ b/src/app/config/Config.ts
@@ -30,6 +30,9 @@ export interface AppConfig {
   dryRun: boolean
   logLevel: LogLevel
   region: Region
+  accessKeyId?: string
+  secretAccessKey?: string
+  sessionToken?: string
   description?: string
 }
 
@@ -55,6 +58,9 @@ export class Config implements AppConfig {
   public readonly description?: string
   public readonly logLevel: LogLevel
   public readonly region: Region
+  public readonly accessKeyId?: string
+  public readonly secretAccessKey?: string
+  public readonly sessionToken?: string
   private readonly maxChunkSize = this.defaultChunkSize * 1024 * 4
   private readonly validator: IValidator
 
@@ -72,6 +78,9 @@ export class Config implements AppConfig {
     this.logLevel = config.logLevel || Config.logLevel
     this.region = config.region || Config.region
     this.dryRun = config.dryRun ?? Config.dryRun
+    this.accessKeyId = config.accessKeyId
+    this.secretAccessKey = config.secretAccessKey
+    this.sessionToken = config.sessionToken
 
     const { description } = config
 

--- a/src/app/config/Validator.ts
+++ b/src/app/config/Validator.ts
@@ -69,8 +69,8 @@ export class Validator implements IValidator {
       vaultName: { type: "string", minLength: 1 },
       dryRun: { type: "boolean" },
       region: { enum: Validator.regions },
-      accessKeyId: { type: "string", minLength: 21, maxLength: 21 },
-      secretAccessKey: { type: "string", minLength: 41, maxLength: 41 },
+      accessKeyId: { type: "string", minLength: 20, maxLength: 20 },
+      secretAccessKey: { type: "string", minLength: 40, maxLength: 40 },
       sessionToken: { type: "string" }
     }
   }

--- a/src/app/config/Validator.ts
+++ b/src/app/config/Validator.ts
@@ -68,7 +68,10 @@ export class Validator implements IValidator {
       logLevel: { enum: ["error", "warn", "info", "verbose", "debug", "silly"] },
       vaultName: { type: "string", minLength: 1 },
       dryRun: { type: "boolean" },
-      region: { enum: Validator.regions }
+      region: { enum: Validator.regions },
+      accessKeyId: { type: "string", minLength: 21, maxLength: 21 },
+      secretAccessKey: { type: "string", minLength: 41, maxLength: 41 },
+      sessionToken: { type: "string" }
     }
   }
 }


### PR DESCRIPTION
Adds command line options to provide AWS access key id, secret access key and session token, as explicit alternative to AWS SDK's default mechanism for acquiring credentials. Closes #2 